### PR TITLE
Add PropType default for components that use checked

### DIFF
--- a/src/Checkbox/Checkbox.js
+++ b/src/Checkbox/Checkbox.js
@@ -13,13 +13,13 @@ Checkbox.propTypes = {
   checked: PropTypes.bool,
 
   /**
-   * @uxpinignoreprop 
+   * @uxpinignoreprop
    * The icon to display when the component is checked.
    */
   checkedIcon: PropTypes.node,
 
   /**
-   * @uxpinignoreprop 
+   * @uxpinignoreprop
    * Override or extend the styles applied to the component.
    */
   classes: PropTypes.object,
@@ -40,13 +40,13 @@ Checkbox.propTypes = {
   disableRipple: PropTypes.bool,
 
   /**
-   * @uxpinignoreprop 
+   * @uxpinignoreprop
    * The icon to display when the component is unchecked.
    */
   icon: PropTypes.node,
 
   /**
-   * @uxpinignoreprop 
+   * @uxpinignoreprop
    * The id of the `input` element.
    */
   id: PropTypes.string,
@@ -60,19 +60,19 @@ Checkbox.propTypes = {
   indeterminate: PropTypes.bool,
 
   /**
-   * @uxpinignoreprop 
+   * @uxpinignoreprop
    * The icon to display when the component is indeterminate.
    */
   indeterminateIcon: PropTypes.node,
 
   /**
-   * @uxpinignoreprop 
+   * @uxpinignoreprop
    * Properties applied to the `input` element.
    */
   inputProps: PropTypes.object,
 
   /**
-   * @uxpinignoreprop 
+   * @uxpinignoreprop
    * Use that property to pass a ref callback to the native input component.
    */
   inputRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
@@ -83,7 +83,7 @@ Checkbox.propTypes = {
   onChange: PropTypes.func,
 
   /**
-   * @uxpinignoreprop 
+   * @uxpinignoreprop
    * The input component property `type`.
    */
   type: PropTypes.string,
@@ -92,6 +92,12 @@ Checkbox.propTypes = {
    * The value of the component.
    */
   value: PropTypes.string
+};
+
+Checkbox.defaultProps = {
+  // NOTE: Checked must be controlled state from the outset, otherwise changing state in the app will trigger an error
+  // see: https://fb.me/react-controlled-components
+  checked: false,
 };
 
 export { Checkbox as default };

--- a/src/FormControlLabel/FormControlLabel.js
+++ b/src/FormControlLabel/FormControlLabel.js
@@ -78,4 +78,10 @@ FormControlLabel.propTypes = {
   value: PropTypes.string
 };
 
+FormControlLabel.defaultProps = {
+  // NOTE: Checked must be controlled state from the outset, otherwise changing state in the app will trigger an error
+  // see: https://fb.me/react-controlled-components
+  checked: false,
+};
+
 export { FormControlLabel as default };

--- a/src/Radio/Radio.js
+++ b/src/Radio/Radio.js
@@ -93,4 +93,10 @@ Radio.propTypes = {
   ])
 };
 
+Radio.defaultProps = {
+  // NOTE: Checked must be controlled state from the outset, otherwise changing state in the app will trigger an error
+  // see: https://fb.me/react-controlled-components
+  checked: false,
+};
+
 export { Radio as default };

--- a/src/Switch/Switch.js
+++ b/src/Switch/Switch.js
@@ -90,4 +90,10 @@ Switch.propTypes = {
   ])
 };
 
+Switch.defaultProps = {
+  // NOTE: Checked must be controlled state from the outset, otherwise changing state in the app will trigger an error
+  // see: https://fb.me/react-controlled-components
+  checked: false,
+};
+
 export { Switch as default };


### PR DESCRIPTION
See https://github.com/UXPin/uxpin-issues/issues/40

There are a few other places that this might be happening in, but for now, this PR should cover the simplest ones -- `checked`.

A more thorough review of the props (which other ones are affected by this, I'm surprised there aren't more) should probably be done to get ahead of any other props that will spit out this error.

For React-specific background context: https://www.robinwieruch.de/react-controlled-components